### PR TITLE
Bugfix generated jar no dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,16 +37,18 @@
             <version>2.2.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.glassfish.tyrus/tyrus-server -->
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>
             <artifactId>tyrus-server</artifactId>
-            <version>1.1</version>
+            <version>2.2.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.glassfish.tyrus/tyrus-container-grizzly-server -->
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>
-            <artifactId>tyrus-container-grizzly</artifactId>
-            <version>1.1</version>
+            <artifactId>tyrus-container-grizzly-server</artifactId>
+            <version>2.2.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,9 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -31,9 +32,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-api</artifactId>
-            <version>1.0</version>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <version>2.2.0</version>
         </dependency>
 
         <dependency>
@@ -48,5 +49,53 @@
             <version>1.1</version>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+
+            <plugin>
+                <!-- Build an executable JAR -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <!-- here we specify that we want to use the main method within the App class -->
+                            <mainClass>org.studnia.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.studnia.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/org/studnia/Main.java
+++ b/src/main/java/org/studnia/Main.java
@@ -1,16 +1,20 @@
 package org.studnia;
 
+import jakarta.websocket.DeploymentException;
 import org.glassfish.tyrus.server.Server;
 import org.studnia.endpoints.SocketHandler;
 
-import javax.websocket.DeploymentException;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
 public class Main {
-    public static void main(String[] args) throws DeploymentException {
-        Server server = new Server("localhost", 8080, "/", SocketHandler.class);
-        server.start();
+    public static void main(String[] args) {
+        Server server = new Server("localhost", 8080, "/", null, SocketHandler.class);
+        try {
+            server.start();
+        } catch (DeploymentException e) {
+            throw new RuntimeException(e);
+        }
 
         try {
             BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));

--- a/src/main/java/org/studnia/endpoints/SocketHandler.java
+++ b/src/main/java/org/studnia/endpoints/SocketHandler.java
@@ -1,7 +1,8 @@
 package org.studnia.endpoints;
 
-import javax.websocket.*;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.*;
+import jakarta.websocket.server.ServerEndpoint;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;


### PR DESCRIPTION
Problem:
Maven generates a .jar that has no dependencies in it
Solution:
Plugin for creating a fat JAR with everything inside that can then be easily run just by:
```
java -jar .\target\chat-service-1.0-SNAPSHOT-jar-with-dependencies.jar
```